### PR TITLE
Add an init command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add a new command `init`
 
 ## [1.3.0] - 2022-01-28
 ### Added

--- a/changelog_manager/__main__.py
+++ b/changelog_manager/__main__.py
@@ -81,5 +81,25 @@ def add(change_type, change_description, changelog):
     changelog_manager.commit()
 
 
+@cli.command()
+@click.option(
+    "--changelog",
+    help="changelog file, default to CHANGELOG.md",
+    default="CHANGELOG.md",
+)
+@click.option(
+    "--force",
+    help="overwrite existing changelog file",
+    is_flag=True,
+    default=False,
+)
+def init(changelog, force):
+    """
+    Create a new changelog file. ex:
+    changelog-manager init
+    """
+    ChangelogManager.init(changelog)
+
+
 if __name__ == "__main__":
     cli()

--- a/changelog_manager/utils.py
+++ b/changelog_manager/utils.py
@@ -1,5 +1,17 @@
 # pylint: disable=protected-access
+from pathlib import Path
+
 import keepachangelog
+
+
+CHANGELOG_HEADER = """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+"""
 
 
 class ChangelogManager:
@@ -35,6 +47,16 @@ class ChangelogManager:
             str: current version number
         """
         return self.__current_version
+
+    @classmethod
+    def init(self, changelog_path: str, force: bool = False) -> None:
+        """
+        Create a new changelog file
+        """
+        if Path(changelog_path).exists() and not force:
+            raise FileExistsError
+        with open(changelog_path, "wt") as f:
+            f.write(CHANGELOG_HEADER)
 
     def add(self, change_type: str, change_description: str) -> None:
         """

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import pytest
+
+from changelog_manager.utils import ChangelogManager
+
+
+def test_changelog_init(tmp_path):
+    tmp_changelog_path = tmp_path / "changelog_init.md"
+    tmp_changelog = str(tmp_changelog_path)
+
+    assert not tmp_changelog_path.exists()
+
+    ChangelogManager.init(tmp_changelog)
+    assert tmp_changelog_path.exists()
+    assert tmp_changelog_path.is_file()
+
+    with pytest.raises(FileExistsError):
+        ChangelogManager.init(tmp_changelog)
+
+    ChangelogManager.init(tmp_changelog, force=True)
+    assert tmp_changelog_path.exists()
+    assert tmp_changelog_path.is_file()
+
+    cm = ChangelogManager(tmp_changelog)
+    assert cm.current is None
+    assert cm.suggest is None
+    assert cm.display("unreleased") == "## [unreleased] - None\n"


### PR DESCRIPTION
This PR adds an `init`command to create a new changelog file.

The stub is defined in `utils.CHANGELOG_HEADER`.