### PR TITLE
Add a --version option to the `release` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add a --version option for the `release` command
 
 ## [1.4.0] - 2024-10-29
 ### Added

--- a/changelog_manager/__main__.py
+++ b/changelog_manager/__main__.py
@@ -1,4 +1,6 @@
 import sys
+from typing import Optional
+
 import click
 from changelog_manager.utils import ChangelogManager
 from changelog_manager._version import __version__
@@ -38,9 +40,10 @@ def suggest(changelog: str) -> None:
     help="changelog file, default to CHANGELOG.md",
     default="CHANGELOG.md",
 )
-def release(changelog: str) -> None:
+@click.option("--version", help="version changes to display", default=None)
+def release(changelog: str, version: Optional[str]) -> None:
     changelog_manager = ChangelogManager(changelog)
-    changelog_manager.release()
+    changelog_manager.release(version)
 
 
 @cli.command(help="display changes according to changelog")

--- a/changelog_manager/utils.py
+++ b/changelog_manager/utils.py
@@ -100,8 +100,8 @@ class ChangelogManager:
                 changes_md += f"- {element}\n"
         return changes_md
 
-    def release(self):
+    def release(self, version):
         """
         create a new release in the changelog using Unreleased part
         """
-        keepachangelog.release(self.__changelog_path)
+        keepachangelog.release(self.__changelog_path, version)


### PR DESCRIPTION
The `release` command currently uses the version suggested by `keepachangelog`, which is not always correct or desired - for example, `keepachangelog` will suggest '1.0.0' whenever there are additions or changes in a pre-release package that is currently on a `0.x.y` version, regardless of whether it is actually ready for a 1.0 release.

This change will allow users to specify a version when running `changelog-manager release` so that they can continue working on a pre-release version without needing to manually edit the changelog to match. It also allows for invocations using other tools to provide a version, for example:
```shell
$ changelog-manager release --version $(poetry version --short)
```
